### PR TITLE
exploit fix

### DIFF
--- a/lua/entities/sent_spawnpoint/init.lua
+++ b/lua/entities/sent_spawnpoint/init.lua
@@ -188,7 +188,10 @@ local heightOfSpawnPointPlusOne = 16
 local function SpawnPointHook( ply )
     local spawnPoint = ply.LinkedSpawnPoint
     if not spawnPoint or not spawnPoint:IsValid() then return end
-    if not util.IsInWorld( spawnPoint:GetPos() ) then return end
+    if not spawnPoint:IsInWorld() then
+        ply:ChatPrint( "Your linked spawn point is in an invalid location" )
+        return
+    end
 
     local spawnPos = spawnPoint:GetPos() + Vector( 0, 0, heightOfSpawnPointPlusOne )
     ply:SetPos( spawnPos )

--- a/lua/entities/sent_spawnpoint/init.lua
+++ b/lua/entities/sent_spawnpoint/init.lua
@@ -188,6 +188,7 @@ local heightOfSpawnPointPlusOne = 16
 local function SpawnPointHook( ply )
     local spawnPoint = ply.LinkedSpawnPoint
     if not spawnPoint or not spawnPoint:IsValid() then return end
+    if not util.IsInWorld( spawnPoint:GetPos() ) then return end
 
     local spawnPos = spawnPoint:GetPos() + Vector( 0, 0, heightOfSpawnPointPlusOne )
     ply:SetPos( spawnPos )


### PR DESCRIPTION
Add a check when respawning to see if the linked mobile spawnpoint is within the playable area.
Prevents exploit where mobile spawnpoint can be buried outside of the playable area, shielding it from damage,