### PR TITLE
Unlink spawnpoints when entering pvp

### DIFF
--- a/lua/entities/sent_spawnpoint/init.lua
+++ b/lua/entities/sent_spawnpoint/init.lua
@@ -199,6 +199,13 @@ end
 hook.Remove( "PlayerSpawn", "SpawnPointHook" )
 hook.Add( "PlayerSpawn", "SpawnPointHook", SpawnPointHook )
 
+local function unlinkSpawnpointWhenEnteringPvp( ply )
+    local linkedSpawnPoint = ply.LinkedSpawnPoint
+    unlinkPlayerFromSpawnPoint( ply, linkedSpawnPoint )
+end
+
+hook.Add( "CFC_PvP_PlayerEnterPvp", "CFC_MobileSpawnpoint_PlayerEnterPvp", unlinkSpawnpointWhenEnteringPvp )
+
 -- Stubs from here on
 
 function ENT:Think() end


### PR DESCRIPTION
This pr aims to remove player their spawnpoint links when entering pvp
Kanban:
https://kanban.cfcservers.org/b/zTdv2hrDmprDAKfxz/cfc-public/wsQoD5tuKMoCjdJrP