### PR TITLE
Add an adjustable spawn radius

### DIFF
--- a/lua/autorun/server/sv_cfc_spawnpoint.lua
+++ b/lua/autorun/server/sv_cfc_spawnpoint.lua
@@ -62,7 +62,7 @@ end
 
 ----- PRIVATE FUNCTIONS -----
 
-function calcSpawnPos( spawnPoint, ply )
+function calcSpawnPos( spawnPoint, _ply )
     local radius = spawnPoint:GetSpawnRadius()
     local spawnPos = spawnPoint:GetPos()
     spawnPos[3] = spawnPos[3] + SPAWN_OFFSET_HEIGHT

--- a/lua/autorun/server/sv_cfc_spawnpoint.lua
+++ b/lua/autorun/server/sv_cfc_spawnpoint.lua
@@ -23,10 +23,12 @@ CFC_SpawnPoints.BANNED_TOOLS = {
 
 local COOLDOWN_ON_PLY_SPAWN = CreateConVar( "cfc_spawnpoints_cooldown_on_ply_spawn", 10, { FCVAR_ARCHIVE }, "When a player spawns, they must wait this many seconds before they can create/link spawn points.", 0, 1000 )
 
+local SPAWN_OFFSET_HEIGHT = 16
+local PLYHULL_MINS = Vector( -16, -16, 0 )
+local PLYHULL_MAXS = Vector( 16, 16, 72 )
+
 local commands = CFC_SpawnPoints.COMMANDS
 local bannedTools = CFC_SpawnPoints.BANNED_TOOLS
-
-local spawnOffsetHeight = 16
 
 util.AddNetworkString( "CFC_SpawnPoints_CreationDenied" )
 util.AddNetworkString( "CFC_SpawnPoints_LinkDenySound" )
@@ -58,6 +60,44 @@ function CFC_SpawnPoints.IsCreationBlocked( ply, data )
 end
 
 
+----- PRIVATE FUNCTIONS -----
+
+function calcSpawnPos( spawnPoint, ply )
+    local radius = spawnPoint:GetSpawnRadius()
+    local spawnPos = spawnPoint:GetPos()
+    spawnPos[3] = spawnPos[3] + SPAWN_OFFSET_HEIGHT
+
+    -- Ignore pitifully small spawn radiuses, no need to trace.
+    if radius <= 16 then return spawnPos end
+
+    -- Trace outwards from the spawnpoint.
+    local radiusEff = math.Rand( radius * 0.125, radius )
+    local traceDir = Angle( 0, math.Rand( 0, 360 ), 0 ):Forward()
+    local trRadial = util.TraceHull( {
+        start = spawnPos,
+        endpos = spawnPos + traceDir * radiusEff,
+        mins = PLYHULL_MINS,
+        maxs = PLYHULL_MAXS,
+        mask = MASK_PLAYERSOLID,
+        collisiongroup = COLLISION_GROUP_PLAYER,
+        filter= TODO,
+    } )
+
+    -- Look downwards for a floor within reasonable distance.
+    local radialPos = trRadial.HitPos - traceDir -- Pull back a little to not immediately hit whatever trRadial hit.
+    local trFloor = util.TraceHull( {
+        start = radialPos,
+        endpos = radialPos + Vector( 0, 0, -radiusEff ),
+        mins = PLYHULL_MINS,
+        maxs = PLYHULL_MAXS,
+        mask = MASK_PLAYERSOLID,
+        collisiongroup = COLLISION_GROUP_PLAYER,
+    } )
+
+    return trFloor.HitPos + Vector( 0, 0, 1 )
+end
+
+
 ----- SETUP -----
 
 hook.Add( "PlayerSpawn", "SpawnPointHook", function( ply )
@@ -69,8 +109,7 @@ hook.Add( "PlayerSpawn", "SpawnPointHook", function( ply )
         return
     end
 
-    local spawnPos = spawnPoint:GetPos() + Vector( 0, 0, spawnOffsetHeight )
-    ply:SetPos( spawnPos )
+    ply:SetPos( calcSpawnPos( spawnPoint, ply ) )
     spawnPoint:OnSpawnedPlayer( ply )
 end )
 

--- a/lua/autorun/server/sv_cfc_spawnpoint.lua
+++ b/lua/autorun/server/sv_cfc_spawnpoint.lua
@@ -70,6 +70,22 @@ function calcSpawnPos( spawnPoint, ply )
     -- Ignore pitifully small spawn radiuses, no need to trace.
     if radius <= 16 then return spawnPos end
 
+    local radialFilter
+    local friendlyFunc = CFC_SpawnPoints.IsFriendly
+
+    if CPPI then
+        radialFilter = function( ent )
+            if not ent.CPPIGetOwner then return true end
+
+            local owner = ent:CPPIGetOwner()
+            if not IsValid( owner ) then return true end
+
+            -- Ignore non-friendly-owned entities, so they can't cover the spawnpoint and force the player to always spawn stuck in the center.
+            -- Doesn't stop enemies from using a massive prop that covers the entire radius, but that should be rare and easy to moderate.
+            return friendlyFunc( spawnPoint, owner )
+        end
+    end
+
     -- Trace outwards from the spawnpoint.
     local radiusEff = math.Rand( radius * 0.125, radius )
     local traceDir = Angle( 0, math.Rand( 0, 360 ), 0 ):Forward()
@@ -80,7 +96,7 @@ function calcSpawnPos( spawnPoint, ply )
         maxs = PLYHULL_MAXS,
         mask = MASK_PLAYERSOLID,
         collisiongroup = COLLISION_GROUP_PLAYER,
-        filter= TODO,
+        filter = radialFilter,
     } )
 
     -- Look downwards for a floor within reasonable distance.

--- a/lua/entities/sent_spawnpoint/cl_init.lua
+++ b/lua/entities/sent_spawnpoint/cl_init.lua
@@ -171,8 +171,10 @@ function ENT:TryDrawSpawnRadius( myTbl )
     -- Don't draw if unfriendly.
     if not myTbl._isFriendlyCache then return end
 
+    radius = math.Round( radius ) -- surface.DrawCircle() only deals in whole numbers, so round it to make tboth circles line up.
     circleScaleVec[1] = radius
     circleScaleVec[2] = radius
+
     spawnRadiusMatrix:SetTranslation( entMeta.GetPos( self ) )
     spawnRadiusCircleMatrix:SetScale( circleScaleVec )
 

--- a/lua/entities/sent_spawnpoint/cl_init.lua
+++ b/lua/entities/sent_spawnpoint/cl_init.lua
@@ -182,7 +182,7 @@ function ENT:TryDrawSpawnRadius( myTbl )
         -- Filled circle
         cam.PushModelMatrix( spawnRadiusCircleMatrix, true ) -- Scale by radius, so circlePoly isn't recreated every frame
             -- Draw poly
-            surface.SetDrawColor( 255, 190, 130, 100 )
+            surface.SetDrawColor( 100, 190, 255, 100 )
             draw.NoTexture()
             surface.DrawPoly( circlePoly )
 
@@ -193,7 +193,7 @@ function ENT:TryDrawSpawnRadius( myTbl )
         cam.PopModelMatrix()
 
         -- Draw circle outline
-        surface.DrawCircle( 0, 0, radius, 255, 150, 50, 255 )
+        surface.DrawCircle( 0, 0, radius, 0, 0, 255, 255 )
 
     cam.PopModelMatrix()
 end

--- a/lua/entities/sent_spawnpoint/cl_init.lua
+++ b/lua/entities/sent_spawnpoint/cl_init.lua
@@ -165,6 +165,7 @@ function ENT:TryDrawSpawnRadius( myTbl )
 
     if radius < 16 or CurTime() > endTime then
         myTbl._showSpawnRadiusEndTime = nil
+        self:SetRenderBounds( self:OBBMins(), self:OBBMaxs() )
         return
     end
 

--- a/lua/entities/sent_spawnpoint/cl_init.lua
+++ b/lua/entities/sent_spawnpoint/cl_init.lua
@@ -175,9 +175,13 @@ function ENT:TryDrawSpawnRadius( myTbl )
     circleScaleVec[1] = radius
     circleScaleVec[2] = radius
 
-    spawnRadiusMatrix:SetTranslation( entMeta.GetPos( self ) )
+    local pos = entMeta.GetPos( self )
+    pos[3] = pos[3] + 1 -- Avoid z-fighting with the ground.
+
+    spawnRadiusMatrix:SetTranslation( pos )
     spawnRadiusCircleMatrix:SetScale( circleScaleVec )
 
+    render.OverrideDepthEnable( true, true )
     cam.PushModelMatrix( spawnRadiusMatrix, true ) -- Handle position (no rotation, as the spawn system doesn't use it either)
         -- Filled circle
         cam.PushModelMatrix( spawnRadiusCircleMatrix, true ) -- Scale by radius, so circlePoly isn't recreated every frame
@@ -197,6 +201,7 @@ function ENT:TryDrawSpawnRadius( myTbl )
             surface.DrawCircle( 0, 0, radius - i, 0, 0, 255, 255 )
         end
     cam.PopModelMatrix()
+    render.OverrideDepthEnable( false )
 end
 
 function ENT:DrawMessage( text, color, alpha, zOffset )

--- a/lua/entities/sent_spawnpoint/cl_init.lua
+++ b/lua/entities/sent_spawnpoint/cl_init.lua
@@ -71,7 +71,6 @@ function ENT:Initialize()
     self._inDrawDistance = false
     self._isFriendlyCache = false
     self._nextFriendlinessCacheTime = 0
-    self._lastDrawDist = 0
 end
 
 function ENT:Draw()
@@ -85,8 +84,6 @@ function ENT:TryDrawMessage( myTbl )
     local ply = LocalPlayer()
     local myPos = entMeta.GetPos( self )
     local eyeDist = vecMeta.Distance( EyePos(), myPos )
-
-    myTbl._lastDrawDist = eyeDist
 
     -- Draw distance check.
     if eyeDist > MESSAGE_DRAW_DISTANCE then
@@ -163,9 +160,8 @@ function ENT:TryDrawSpawnRadius( myTbl )
         return
     end
 
-    -- Don't draw if unfriendly or outside of both draw distance and spawn radius.
+    -- Don't draw if unfriendly.
     if not myTbl._isFriendlyCache then return end
-    if not myTbl._inDrawDistance and myTbl._lastDrawDist > radius * 1.25 then return end
 
     spawnRadiusMatrix:SetTranslation( entMeta.GetPos( self ) )
     spawnRadiusMatrix:SetAngles( entMeta.GetAngles( self ) )

--- a/lua/entities/sent_spawnpoint/cl_init.lua
+++ b/lua/entities/sent_spawnpoint/cl_init.lua
@@ -193,8 +193,9 @@ function ENT:TryDrawSpawnRadius( myTbl )
         cam.PopModelMatrix()
 
         -- Draw circle outline
-        surface.DrawCircle( 0, 0, radius, 0, 0, 255, 255 )
-
+        for i = 0, 4 do
+            surface.DrawCircle( 0, 0, radius - i, 0, 0, 255, 255 )
+        end
     cam.PopModelMatrix()
 end
 

--- a/lua/entities/sent_spawnpoint/cl_init.lua
+++ b/lua/entities/sent_spawnpoint/cl_init.lua
@@ -71,6 +71,7 @@ function ENT:Initialize()
     self._inDrawDistance = false
     self._isFriendlyCache = false
     self._nextFriendlinessCacheTime = 0
+    self._lastDrawDist = 0
 end
 
 function ENT:Draw()
@@ -84,6 +85,8 @@ function ENT:TryDrawMessage( myTbl )
     local ply = LocalPlayer()
     local myPos = entMeta.GetPos( self )
     local eyeDist = vecMeta.Distance( EyePos(), myPos )
+
+    myTbl._lastDrawDist = eyeDist
 
     -- Draw distance check.
     if eyeDist > MESSAGE_DRAW_DISTANCE then
@@ -159,6 +162,10 @@ function ENT:TryDrawSpawnRadius( myTbl )
         myTbl._showSpawnRadiusEndTime = nil
         return
     end
+
+    -- Don't draw if unfriendly or outside of both draw distance and spawn radius.
+    if not myTbl._isFriendlyCache then return end
+    if not myTbl._inDrawDistance and myTbl._lastDrawDist > radius * 1.25 then return end
 
     spawnRadiusMatrix:SetTranslation( entMeta.GetPos( self ) )
     spawnRadiusMatrix:SetAngles( entMeta.GetAngles( self ) )

--- a/lua/entities/sent_spawnpoint/cl_init.lua
+++ b/lua/entities/sent_spawnpoint/cl_init.lua
@@ -45,6 +45,8 @@ surface.CreateFont( "CFC_SpawnPoints_3D2DMessage", {
     shadow = false,
 } )
 
+local spawnRadiusMatrix = Matrix()
+
 
 ----- PRIVATE FUNCTIONS -----
 
@@ -75,6 +77,7 @@ function ENT:Draw()
     local myTbl = entMeta.GetTable( self )
     entMeta.DrawModel( self )
     myTbl.TryDrawMessage( self, myTbl )
+    myTbl.TryDrawSpawnRadius( self, myTbl )
 end
 
 function ENT:TryDrawMessage( myTbl )
@@ -144,6 +147,25 @@ function ENT:TryDrawMessage( myTbl )
             self:DrawMessage( string.format( MESSAGE_TEXT_LINKHINT, string.upper( useKey ) ), MESSAGE_COLOR_LINKHINT, alpha )
         end
     end
+end
+
+function ENT:TryDrawSpawnRadius( myTbl )
+    local endTime = myTbl._showSpawnRadiusEndTime
+    if not endTime then return end
+
+    local radius = self:GetSpawnRadius()
+
+    if radius < 16 or CurTime() > endTime then
+        myTbl._showSpawnRadiusEndTime = nil
+        return
+    end
+
+    spawnRadiusMatrix:SetTranslation( entMeta.GetPos( self ) )
+    spawnRadiusMatrix:SetAngles( entMeta.GetAngles( self ) )
+
+    cam.PushModelMatrix( spawnRadiusMatrix, true )
+    surface.DrawCircle( 0, 0, radius, 255, 150, 50, 255 )
+    cam.PopModelMatrix()
 end
 
 function ENT:DrawMessage( text, color, alpha, zOffset )

--- a/lua/entities/sent_spawnpoint/shared.lua
+++ b/lua/entities/sent_spawnpoint/shared.lua
@@ -17,7 +17,7 @@ function ENT:SetupDataTables()
 
     if SERVER then return end
 
-    self:NetworkVarNotify( "SpawnRadius", function( ent, _, _, spawnRadius )
+    self:NetworkVarNotify( "SpawnRadius", function( ent )
         ent._showSpawnRadiusEndTime = CurTime() + 3
     end )
 end

--- a/lua/entities/sent_spawnpoint/shared.lua
+++ b/lua/entities/sent_spawnpoint/shared.lua
@@ -5,6 +5,7 @@ ENT.Author			= "Esik1er"
 
 ENT.Spawnable			= true
 ENT.AdminSpawnable		= true
+ENT.Editable	     	= true
 
 
 function ENT:SetupDataTables()
@@ -12,4 +13,11 @@ function ENT:SetupDataTables()
     self:NetworkVar( "Float", 0, "CreationCooldownEndTime" )
     self:NetworkVar( "Float", 1, "PointMaxHealth" ) -- Starfall can manipulate :SetMaxHealth(), so bypass it by using a custom NetworkVar.
     self:NetworkVar( "Float", 2, "PointHealth" )
+    self:NetworkVar( "Float", 3, "SpawnRadius", { KeyName = "spawn_radius", Edit = { type = "Float", title = "Spawn Radius", order = 1, min = 0, max = 1000 } } )
+
+    if SERVER then return end
+
+    self:NetworkVarNotify( "SpawnRadius", function( ent, _, _, spawnRadius )
+        ent._showSpawnRadiusEndTime = CurTime() + 3
+    end )
 end

--- a/lua/entities/sent_spawnpoint/shared.lua
+++ b/lua/entities/sent_spawnpoint/shared.lua
@@ -17,7 +17,8 @@ function ENT:SetupDataTables()
 
     if SERVER then return end
 
-    self:NetworkVarNotify( "SpawnRadius", function( ent )
+    self:NetworkVarNotify( "SpawnRadius", function( ent, _, _, radius )
         ent._showSpawnRadiusEndTime = CurTime() + 5
+        ent:SetRenderBounds( Vector( -radius, -radius, -radius ), Vector( radius, radius, radius ) )
     end )
 end

--- a/lua/entities/sent_spawnpoint/shared.lua
+++ b/lua/entities/sent_spawnpoint/shared.lua
@@ -18,6 +18,6 @@ function ENT:SetupDataTables()
     if SERVER then return end
 
     self:NetworkVarNotify( "SpawnRadius", function( ent )
-        ent._showSpawnRadiusEndTime = CurTime() + 3
+        ent._showSpawnRadiusEndTime = CurTime() + 5
     end )
 end


### PR DESCRIPTION
- Spawns players in an area around their spawnpoint, so it's harder to spawncamp them.
- Uses hull traces to prevent getting spawned in the world, inside of your base's props, or getting spawned *outside* your base past a wall.
  - Also does a simple floor-finding trace to snap players to the ground for convenience.
  - The first trace ignores props owned by unfriendly players, so they can't just cover up the spawnpoint and trap them into one spot again.
- Spawn radius is adjustable, with a visual overlay that lingers for a few seconds when the radius is changed.
- Default spawn radius is 150.