### PR TITLE
Apply spawn cooldown when health reaches 0 as well

### DIFF
--- a/lua/autorun/sh_cfc_spawnpoint.lua
+++ b/lua/autorun/sh_cfc_spawnpoint.lua
@@ -45,7 +45,7 @@ function CFC_SpawnPoints.IsFriendly( spawnPoint, ply )
 end
 
 function CFC_SpawnPoints.SetSpawnCooldownEndTime( ply, time )
-    ply._cfcSpawnPoints_SpawnCooldownEndTime = time
+    ply._cfcSpawnPoints_SpawnCooldownEndTime = math.max( time, ply._cfcSpawnPoints_SpawnCooldownEndTime or 0 )
 
     if CLIENT then return end
 


### PR DESCRIPTION
Was dealing with base defenders earlier and saw them immediately respawning spawnpoints and connecting after the short linking cooldown. Not sure how I missed this one lol.

Doesn't apply the cooldown from undoing the spawnpoint, only when its health is depleted.