### PR TITLE
Account for solid brushes that don't form a void space

### DIFF
--- a/lua/autorun/server/sv_cfc_spawnpoint.lua
+++ b/lua/autorun/server/sv_cfc_spawnpoint.lua
@@ -125,6 +125,15 @@ hook.Add( "PlayerSpawn", "SpawnPointHook", function( ply )
         return
     end
 
+    local pos = spawnPoint:GetPos()
+    local mins = spawnPoint:OBBMins()
+    mins[3] = 0
+
+    if util.TraceHull( pos, pos, mins, spawnPoint:OBBMaxs(), nil, MASK_SOLID, COLLISION_GROUP_WORLD ).Hit then
+        ply:ChatPrint( "Your linked spawn point is in an invalid location" )
+        return
+    end
+
     ply:SetPos( calcSpawnPos( spawnPoint, ply ) )
     spawnPoint:OnSpawnedPlayer( ply )
 end )

--- a/lua/autorun/server/sv_cfc_spawnpoint.lua
+++ b/lua/autorun/server/sv_cfc_spawnpoint.lua
@@ -129,7 +129,7 @@ hook.Add( "PlayerSpawn", "SpawnPointHook", function( ply )
     local mins = spawnPoint:OBBMins()
     mins[3] = 0
 
-    if util.TraceHull( pos, pos, mins, spawnPoint:OBBMaxs(), nil, MASK_SOLID, COLLISION_GROUP_WORLD ).Hit then
+    if util.TraceHull( pos, pos, mins, spawnPoint:OBBMaxs(), nil, MASK_SOLID_BRUSHONLY, COLLISION_GROUP_WORLD ).HitWorld then
         ply:ChatPrint( "Your linked spawn point is in an invalid location" )
         return
     end


### PR DESCRIPTION
Prevents people from putting spawnpoints inside of solid brushes like this pole on the bigcity towers which don't constitute a void space inside.
<img width="508" height="736" alt="image" src="https://github.com/user-attachments/assets/33128b14-b268-4b4e-a501-e588ef4bf037" />
<img width="1175" height="1001" alt="image" src="https://github.com/user-attachments/assets/d4aee987-58e0-49f0-9cc5-79e3cbe6714c" />
